### PR TITLE
Enable support for asciidoctor

### DIFF
--- a/LSP-Grammarly.sublime-settings
+++ b/LSP-Grammarly.sublime-settings
@@ -1,5 +1,5 @@
 {
-  "selector": "text.html.markdown | text.tex.latex",
+  "selector": "text.asciidoc | text.html.markdown | text.tex.latex",
 
   "initializationOptions": {
     "clientId": "client_BaDkMgx4X19X9UxxYRCXZo"


### PR DESCRIPTION
Enable support for asciidoctor (.asciidoc/.adoc) files (used by self-publishers and mainstream publishers like Manning)